### PR TITLE
Etapa 03: adiciona Zabbix via Docker Compose e integra MikroTik via SNMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,13 @@ Registro cronológico da evolução deste laboratório de observabilidade.
 - Job mikrotik-snmp confirmado com health up no Prometheus
 - Integracao validada visualmente no Grafana (Explore) com metrica ifHCInOctets da interface ether2
 - Atualizado docs/inventory.md, docs/stability-criteria.md e docs/runbooks/snmp-troubleshooting-mikrotik.md
+
+## 2026-08-30
+
+- Adicionado Zabbix (server, web, banco PostgreSQL) via Docker Compose como segundo pilar de monitoramento
+- Troubleshooting documentado: conflito de porta 8080 com container evolution-evolution-api-1, resolvido mapeando zabbix-web para porta 8081
+- Senha padrao do usuario Admin do Zabbix trocada por seguranca
+- Host MikroTik HomeLab criado no Zabbix via SNMP, com template Network Generic Device by SNMP
+- Troubleshooting documentado: campo SNMP community pre-preenchido incorretamente, corrigido para "public"
+- Confirmados 75 itens coletando dados reais via LLD (ICMP + interfaces, incluindo pppoe-out1)
+- Atualizado docs/inventory.md, docs/stability-criteria.md; criado docs/runbooks/zabbix-setup-troubleshooting.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,48 @@ services:
     ports:
       - "9116:9116"
 
+  zabbix-db:
+    image: postgres:16
+    container_name: zabbix-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=zabbix
+      - POSTGRES_PASSWORD=zabbix
+      - POSTGRES_DB=zabbix
+    volumes:
+      - zabbix_db_data:/var/lib/postgresql/data
+
+  zabbix-server:
+    image: zabbix/zabbix-server-pgsql:latest
+    container_name: zabbix-server
+    restart: unless-stopped
+    environment:
+      - DB_SERVER_HOST=zabbix-db
+      - POSTGRES_USER=zabbix
+      - POSTGRES_PASSWORD=zabbix
+      - POSTGRES_DB=zabbix
+    ports:
+      - "10051:10051"
+    depends_on:
+      - zabbix-db
+
+  zabbix-web:
+    image: zabbix/zabbix-web-nginx-pgsql:latest
+    container_name: zabbix-web
+    restart: unless-stopped
+    environment:
+      - DB_SERVER_HOST=zabbix-db
+      - POSTGRES_USER=zabbix
+      - POSTGRES_PASSWORD=zabbix
+      - POSTGRES_DB=zabbix
+      - ZBX_SERVER_HOST=zabbix-server
+      - PHP_TZ=America/Bahia
+    ports:
+      - "8081:8080"
+    depends_on:
+      - zabbix-server
+
 volumes:
   prometheus_data:
   grafana_data:
+  zabbix_db_data:

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -8,3 +8,5 @@ Lista viva de tudo que esta sendo monitorado neste laboratorio. Atualizar sempre
 | Prometheus | Servico de monitoramento | Self-scrape | 9090 | Ativo | 2026-08-27 |
 | Grafana | Visualizacao | N/A | 3001 (mapeada para 3000) | Ativo | 2026-08-27 |
 | MikroTik hEX S (HomeLab) | Roteador | SNMP v2c via snmp_exporter (Prometheus) | 161/UDP + 9116/TCP | Ativo | 2026-08-28 |
+| Zabbix (server + web + db) | Serviço de monitoramento | Docker Compose | 8081 (web), 10051 (server) | Ativo | 2026-08-30 |
+| MikroTik hEX S (via Zabbix) | Roteador | SNMP v2c direto no Zabbix (host MikroTik HomeLab) | 161/UDP | Ativo | 2026-08-30 |

--- a/docs/runbooks/zabbix-setup-troubleshooting.md
+++ b/docs/runbooks/zabbix-setup-troubleshooting.md
@@ -1,0 +1,34 @@
+# Runbook: Configuracao do Zabbix (Docker Compose)
+
+## Contexto
+
+Adicao do Zabbix (server, web, banco PostgreSQL) ao laboratorio via Docker Compose, como segundo pilar de monitoramento ao lado do Prometheus/Grafana.
+
+## Problema 1: conflito de porta 8080
+
+Ao subir o zabbix-web pela primeira vez, o Docker retornou erro de porta ja alocada:
+
+Bind for :::8080 failed: port is already allocated
+
+Diagnostico:
+
+sudo ss -tlnp | grep 8080
+docker ps --format "table {{.Names}}\t{{.Ports}}" | grep 8080
+
+Resultado: a porta 8080 ja estava em uso pelo container evolution-evolution-api-1 (stack de automacao/IA local rodando no mesmo host).
+
+Solucao: mapear o zabbix-web para a porta 8081 externa, mantendo a porta interna 8080 do container:
+
+ports:
+  - "8081:8080"
+
+## Problema 2: campo SNMP community pre-preenchido incorretamente
+
+Ao criar o host do
+MikroTik no Zabbix com interface SNMP, o campo "SNMP community" veio pre-preenchido com uma macro padrao ({$SNMP_COMMUNITY}) em vez do valor real usado no equipamento (public, ja validado nos testes anteriores com snmpwalk).
+
+Solucao: substituir manualmente o valor do campo por "public" antes de salvar o host.
+
+## Resultado
+
+Apos as duas correcoes, o host MikroTik HomeLab foi criado com sucesso no Zabbix, com o template "Network Generic Device by SNMP" vinculado. A descoberta automatica (LLD) identificou 75 itens, incluindo ICMP ping/loss/response time e metricas de todas as interfaces (bridge, ether1-5, pppoe-out1), confirmando coleta de dados real minutos apos a configuracao.

--- a/docs/stability-criteria.md
+++ b/docs/stability-criteria.md
@@ -9,6 +9,7 @@ Este documento define os indicadores (SLI) e objetivos (SLO) de estabilidade par
 | Grafana | Carregamento do dashboard após restart | Dashboard exibe dados em até 60s após `docker compose up -d` | Teste manual documentado com print |
 | Stack (geral) | Recuperação após reinício completo | Stack completo (`down && up -d`) volta a coletar sem intervenção manual | Teste documentado em `incidents/` ou `etapas/` |
 | MikroTik (SNMP via Prometheus) | Disponibilidade do target mikrotik-snmp | up{job="mikrotik-snmp"} == 1 por >= 99% do tempo em janela de 24h | Query no Prometheus + grafico no Grafana |
+| Zabbix | Disponibilidade do zabbix-server | Zabbix server is running = Yes por >= 99% do tempo | Dashboard Global view + item zabbix[process,...] |
 
 ## Histórico de validação
 
@@ -19,3 +20,5 @@ Este documento define os indicadores (SLI) e objetivos (SLO) de estabilidade par
 
 | 2026-08-28 | MikroTik hEX S | up (apos correcao de firewall e community) | snmpwalk via ThinkCentre |
 | 2026-08-29 | MikroTik hEX S (via Prometheus) | up | curl /api/v1/targets + grafico no Grafana |
+| 2026-08-30 | Zabbix (server+web+db) | up | Dashboard Global view, Zabbix server is running: Yes |
+| 2026-08-30 | MikroTik hEX S (via Zabbix) | up | Latest data com 75 itens coletando (LLD SNMP) |


### PR DESCRIPTION
- Adicionado Zabbix (server, web, banco PostgreSQL) via Docker Compose como segundo pilar de monitoramento
- Troubleshooting documentado: conflito de porta 8080 com container evolution-evolution-api-1, resolvido mapeando zabbix-web para porta 8081
- Senha padrao do usuario Admin do Zabbix trocada por seguranca
- Host MikroTik HomeLab criado no Zabbix via SNMP, com template Network Generic Device by SNMP
- Troubleshooting documentado: campo SNMP community pre-preenchido incorretamente, corrigido para "public"
- Confirmados 75 itens coletando dados reais via LLD (ICMP + interfaces, incluindo pppoe-out1)
- Atualizado docs/inventory.md, docs/stability-criteria.md; criado docs/runbooks/zabbix-setup-troubleshooting.md