### PR TITLE
Etapa 07: runbooks SRE (InstanceDown, HighCPU, HighDisk) e runbook de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,11 @@ Registro cronológico da evolução deste laboratório de observabilidade.
 - Teste real de ponta a ponta com stress-ng: alerta HighCPUUsageThinkCentre transicionou inactive -> pending -> firing -> resolved, confirmado no Prometheus, no Alertmanager, por e-mail e por webhook (webhook-receiver/alerts.log)
 - Atualizado docs/inventory.md e docs/stability-criteria.md
 - Etapa 05 (Alertmanager) concluida para a regra HighCPUUsageThinkCentre; HighDiskUsageThinkCentre e InstanceDown ainda pendentes de teste real
+## 2026-09-12
+- Iniciada a Etapa 07 (Runbooks SRE), consolidando os padroes observados nos Incidentes 01 e 02 e no teste de ponta a ponta do Alertmanager
+- Criado docs/runbooks/runbook-instancedown.md com referencia real de MTTD/MTTR dos Incidentes 01 e 02
+- Criado docs/runbooks/runbook-highcpu-thinkcentre.md com referencia ao teste real do Alertmanager (stress-ng)
+- Criado docs/runbooks/runbook-highdisk-thinkcentre.md com referencia ao teste real do Alertmanager (fallocate), incluindo observacao pendente sobre falha de entrega do resolved no webhook
+- Criado docs/runbooks/runbook-mudanca-planejada.md, formalizando a diferenca entre incidente (nao planejado) e manutencao (planejada e silenciada no Alertmanager)
+- Criada pasta docs/mudancas/ (paralela a incidents/) para registrar mudancas planejadas na infraestrutura
+- Criado docs/mudancas/mudanca-01-realocacao-mikrotik-thinkcentre.md, planejando a realocacao fisica do MikroTik e do ThinkCentre e a instalacao futura de um mini rack

--- a/docs/mudancas/mudanca-01-realocacao-mikrotik-thinkcentre.md
+++ b/docs/mudancas/mudanca-01-realocacao-mikrotik-thinkcentre.md
@@ -1,0 +1,25 @@
+# Mudança Planejada 01: Realocação física do MikroTik e ThinkCentre
+
+## Status
+Planejada para execução em [DATA]
+
+## Escopo
+Mover o MikroTik e o ThinkCentre para um ambiente dedicado preparado especificamente para eles, com previsão de instalação futura de um mini rack para novos equipamentos.
+
+## Impacto esperado
+- MikroTik: perda de conectividade durante o transporte/reconexão (alerta InstanceDown esperado)
+- ThinkCentre: possível interrupção de containers durante o desligamento/remontagem (alerta InstanceDown esperado)
+
+## Timestamps
+- [ ] Criação do silence:
+- [ ] Início da intervenção física:
+- [ ] Religamento MikroTik:
+- [ ] Religamento ThinkCentre:
+- [ ] Targets voltaram a UP no Prometheus:
+- [ ] Fim/expiração do silence:
+
+## Evidências
+(preencher durante a execução: prints do silence ativo, prints do Prometheus Targets antes/depois)
+
+## Runbook de referência
+docs/runbooks/runbook-mudanca-planejada.md

--- a/docs/runbooks/runbook-highcpu-thinkcentre.md
+++ b/docs/runbooks/runbook-highcpu-thinkcentre.md
@@ -1,0 +1,38 @@
+# Runbook: HighCPUUsageThinkCentre
+
+## Alerta
+- **Nome:** HighCPUUsageThinkCentre
+- **Severidade:** Alta
+- **Regra Prometheus:** uso de CPU do ThinkCentre acima do limiar definido em rules.yml, sustentado pelo tempo de `for`
+- **Canais de notificação:** e-mail (Gmail SMTP) + webhook local
+
+## O que significa
+O ThinkCentre está com uso de CPU sustentado acima do normal. Pode indicar processo travado, carga de trabalho legítima alta, ou (em teste) geração artificial de carga.
+
+## Verificação imediata
+1. Checar status do alerta no Prometheus: Alerts > HighCPUUsageThinkCentre
+2. Confirmar entrega da notificação no Alertmanager (e-mail e/ou webhook)
+3. `top` ou `htop` no ThinkCentre para identificar processo consumindo CPU
+4. `docker stats` para ver se algum container específico está consumindo mais que o esperado
+
+## Diagnóstico
+1. Identificar processo/container responsável via `top`/`docker stats`
+2. Verificar se é pico pontual (job, backup, atualização) ou sustentado
+3. Checar Grafana (dashboard CPU) para visualizar tendência e comparar com histórico
+
+## Resolução
+1. Processo legítimo (pico esperado): aguardar normalização e documentar
+2. Processo travado/anômalo: reiniciar o serviço ou container responsável
+3. Container consumindo demais: considerar limitar recursos no docker-compose.yml (cpus:)
+4. Confirmar retorno ao normal: Grafana e Prometheus > Alerts > resolved
+
+## Escalonamento
+Ambiente de laboratório pessoal, sem plantão formal. Em produção real, esse seria o ponto de acionar o responsável de plantão se a CPU não normalizar em X minutos ou se impactar outros serviços.
+
+## Referência real
+Testado de ponta a ponta na etapa do Alertmanager: carga de CPU gerada via stress-ng no ThinkCentre, alerta passou por inactive → pending → firing no Prometheus, e foi entregue com sucesso nos dois canais (e-mail e webhook), confirmado em webhook-receiver/alerts.log. Ainda não há incidente real (não simulado) registrado para este alerta.
+
+## Prevenção
+- Monitorar tendência de CPU no Grafana para antecipar picos recorrentes
+- Ajustar o limiar e o `for` da regra caso picos curtos e legítimos gerem falso positivo
+- Definir limites de CPU por container no docker-compose.yml para conter processos anômalos

--- a/docs/runbooks/runbook-highdisk-thinkcentre.md
+++ b/docs/runbooks/runbook-highdisk-thinkcentre.md
@@ -1,0 +1,38 @@
+# Runbook: HighDiskUsageThinkCentre
+
+## Alerta
+- **Nome:** HighDiskUsageThinkCentre
+- **Severidade:** Alta
+- **Regra Prometheus:** espaço livre em disco do ThinkCentre abaixo do limiar definido em rules.yml
+- **Canais de notificação:** e-mail (Gmail SMTP) + webhook local
+
+## O que significa
+O disco do ThinkCentre está com espaço livre abaixo do esperado. Pode indicar acúmulo de logs, imagens Docker não utilizadas, dados de métricas (Prometheus TSDB) crescendo, ou uso legítimo crescente.
+
+## Verificação imediata
+1. Checar status do alerta no Prometheus: Alerts > HighDiskUsageThinkCentre
+2. Confirmar entrega da notificação no Alertmanager (e-mail e/ou webhook)
+3. `df -h` no ThinkCentre para confirmar percentual real de uso
+4. `du -sh /var/lib/docker/*` para identificar consumo por volumes/imagens Docker
+
+## Diagnóstico
+1. Identificar maior consumidor: logs de container, volumes órfãos, imagens antigas, dados do Prometheus
+2. `docker system df` para visão geral de espaço usado por Docker
+3. Checar Grafana (dashboard de disco) para ver velocidade de crescimento
+
+## Resolução
+1. Limpeza segura: `docker system prune` (imagens/containers/volumes não utilizados)
+2. Logs grandes: rotacionar ou truncar logs antigos
+3. Retenção do Prometheus: revisar `--storage.tsdb.retention.time` se TSDB for o principal consumidor
+4. Confirmar retorno ao normal: `df -h` e Prometheus > Alerts > resolved
+
+## Escalonamento
+Ambiente de laboratório pessoal, sem plantão formal. Em produção real, esse seria o ponto de acionar o responsável de plantão se o disco continuar subindo após a limpeza inicial.
+
+## Referência real
+Testado de ponta a ponta na etapa do Alertmanager: espaço ocupado artificialmente via `fallocate` (23% para 14% livre), alerta disparou firing corretamente. Observação registrada: o webhook não recebeu a notificação de resolved (só o e-mail chegou) — ponto de atenção para investigar na configuração do webhook-receiver ou do Alertmanager.
+
+## Prevenção
+- Configurar rotação de log automática nos containers (`logging: driver: json-file, options: max-size`)
+- Revisar periodicamente a retenção do Prometheus TSDB
+- Investigar a falha de entrega do resolved no webhook antes de depender dele em cenário real

--- a/docs/runbooks/runbook-instancedown.md
+++ b/docs/runbooks/runbook-instancedown.md
@@ -1,0 +1,41 @@
+# Runbook: InstanceDown
+
+## Alerta
+- **Nome:** InstanceDown
+- **Severidade:** Crítica
+- **Regra Prometheus:** target fora do ar (up == 0) por tempo definido em rules.yml
+- **Canais de notificação:** e-mail (Gmail SMTP) + webhook local
+
+## O que significa
+Um target monitorado (ex: snmp-exporter, node-exporter) parou de responder ao scrape do Prometheus. Pode indicar container parado, falha de rede ou equipamento desligado.
+
+## Verificação imediata
+1. Checar status do alerta no Prometheus: Alerts > InstanceDown
+2. Confirmar no Alertmanager se a notificação foi entregue (e-mail e/ou webhook)
+3. `docker ps` no ThinkCentre para ver se o container relacionado está rodando
+4. Se for equipamento externo (ex: MikroTik), testar ping direto: `ping 192.168.88.1`
+
+## Diagnóstico
+1. `docker logs <container>` para erro de crash
+2. Se container ok mas sem resposta: checar rede (`docker network inspect`)
+3. Se equipamento físico: checar energia, cabo, porta de switch
+
+## Resolução
+1. Container parado: `docker compose up -d <serviço>`
+2. Equipamento físico desligado: religar e confirmar boot completo
+3. Confirmar retorno do target: Prometheus > Targets > status UP
+
+## Escalonamento
+Ambiente de laboratório pessoal, sem plantão formal. Em produção real, esse seria o ponto de acionar o responsável de plantão se não resolvido em X minutos.
+
+## Referência real (Incidentes 01 e 02)
+| Incidente | Causa | MTTD | MTTR |
+|---|---|---|---|
+| 01 | Container snmp-exporter parado (simulado) | ~30s | 1h42min |
+| 02 | Desligamento físico real do MikroTik | ~30s | ~5min |
+
+MTTD consistente (~30s) nos dois casos, validando o tempo de detecção do Prometheus/Alertmanager. MTTR varia conforme disponibilidade do operador, não da ferramenta.
+
+## Prevenção
+- Manter scrape_interval e for adequados pra não gerar falso positivo em reinícios rápidos
+- Documentar toda mudança física planejada como manutenção (ver runbook de mudança planejada), não como incidente

--- a/docs/runbooks/runbook-mudanca-planejada.md
+++ b/docs/runbooks/runbook-mudanca-planejada.md
@@ -1,0 +1,46 @@
+# Runbook: Mudança Planejada (Maintenance Window)
+
+## Objetivo
+Procedimento padrão para qualquer intervenção física ou lógica planejada no laboratório (realocação de equipamento, novo hardware, reconfiguração), evitando que alarmes esperados sejam tratados como incidentes reais.
+
+## Diferença entre Incidente e Manutenção
+- **Incidente:** falha não planejada, gera MTTD/MTTR como métrica de resposta a problema
+- **Manutenção:** interrupção planejada e comunicada previamente (a si mesmo, no laboratório), com alarme esperado e silenciado
+
+## Pré-requisitos antes de iniciar
+1. Definir escopo exato: quais equipamentos/serviços serão afetados
+2. Definir janela estimada de duração
+3. Registrar horário de início pretendido
+
+## Procedimento
+
+### Antes
+1. Criar Silence no Alertmanager para os alertas esperados (ex: InstanceDown do equipamento afetado), com duração um pouco maior que a janela estimada
+2. Registrar timestamp de início do silence
+3. Confirmar no Alertmanager que o silence está ativo (Silences > Active)
+
+### Durante
+1. Registrar timestamp de início da intervenção física/lógica
+2. Executar a mudança (desligar, mover, remontar, religar)
+3. Registrar timestamp de religamento/retorno
+
+### Depois
+1. Confirmar retorno dos targets no Prometheus (Targets > status UP)
+2. Confirmar que os alertas voltaram a inactive/resolved
+3. Remover o Silence manualmente se ainda estiver ativo (ou deixar expirar)
+4. Registrar timestamp de fim da manutenção
+
+## Checklist de evidência a coletar
+- [ ] Timestamp: criação do silence
+- [ ] Timestamp: início da intervenção física
+- [ ] Timestamp: religamento
+- [ ] Timestamp: targets voltaram a UP no Prometheus
+- [ ] Timestamp: fim/expiração do silence
+- [ ] Print ou log do Alertmanager mostrando o silence ativo
+- [ ] Print do Prometheus Targets antes e depois
+
+## Diferença de tratamento no changelog
+Mudanças planejadas entram no CHANGELOG.md e em `docs/mudancas/` (não em `incidents/`), mantendo a distinção clara entre resposta a falha e evolução controlada da infraestrutura.
+
+## Referência
+Este runbook nasceu da necessidade real de mover o MikroTik e o ThinkCentre para um novo local organizado, com preparação para instalação futura de mini rack.


### PR DESCRIPTION
Consolida os padroes observados nos Incidentes 01 e 02 e no teste de
ponta a ponta do Alertmanager em runbooks formais de resposta a alerta:

- runbook-instancedown.md
- runbook-highcpu-thinkcentre.md
- runbook-highdisk-thinkcentre.md

Introduz tambem a distincao entre incidente (falha nao planejada) e
mudanca planejada (manutencao com silence no Alertmanager), via
runbook-mudanca-planejada.md e a nova pasta docs/mudancas/, ja
preparando o terreno para a realocacao fisica do MikroTik e do
ThinkCentre.